### PR TITLE
feat: redirect authenticated users from homepage to /dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,19 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+const isHomePage = createRouteMatcher(["/"]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
     await auth.protect();
+  }
+
+  if (isHomePage(req)) {
+    const { userId } = await auth();
+    if (userId) {
+      return NextResponse.redirect(new URL("/dashboard", req.url));
+    }
   }
 });
 


### PR DESCRIPTION
If a logged-in user navigates to the root '/' page, they are now redirected to '/dashboard' via middleware using Clerk's auth().