### PR TITLE
fix: apply theme-aware colors to home page for unauthenticated users

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,10 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-black font-sans">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-start gap-16 py-32 px-16 bg-black sm:items-start">
+    <div className="flex min-h-screen items-center justify-center bg-background font-sans">
+      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-start gap-16 py-32 px-16 bg-background sm:items-start">
         <Image
-          className="invert"
+          className="dark:invert"
           src="/next.svg"
           alt="Next.js logo"
           width={100}
@@ -13,21 +13,21 @@ export default function Home() {
           priority
         />
         <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-zinc-50">
+          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-foreground">
             To get started, edit the page.tsx file.
           </h1>
-          <p className="max-w-md text-lg leading-8 text-white">
+          <p className="max-w-md text-lg leading-8 text-foreground">
             Looking for a starting point or more instructions? Head over to{" "}
             <a
               href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-white"
+              className="font-medium text-foreground underline"
             >
               Templates
             </a>{" "}
             or the{" "}
             <a
               href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-white"
+              className="font-medium text-foreground underline"
             >
               Learning
             </a>{" "}
@@ -36,13 +36,13 @@ export default function Home() {
         </div>
         <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
           <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
+            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:opacity-80 md:w-[158px]"
             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
             target="_blank"
             rel="noopener noreferrer"
           >
             <Image
-              className="brightness-0"
+              className="dark:invert"
               src="/vercel.svg"
               alt="Vercel logomark"
               width={16}
@@ -51,7 +51,7 @@ export default function Home() {
             Deploy Now
           </a>
           <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-white/20 px-5 text-white transition-colors hover:border-transparent hover:bg-white/10 md:w-[158px]"
+            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-border px-5 text-foreground transition-colors hover:bg-accent md:w-[158px]"
             href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
Replace hardcoded bg-black, text-zinc-50, text-white classes with theme-aware alternatives (bg-background, text-foreground, border-border) so Dark/Light/System mode toggle affects the full page, not just the header.

Fixes #12